### PR TITLE
Pre-install default Rails gems

### DIFF
--- a/provision-user-install.sh
+++ b/provision-user-install.sh
@@ -19,3 +19,8 @@ ln -s /vagrant $HOME/workspace
 gem install rails --version "$RAILSBRIDGE_RAILS_VERSION"
 # Keep this until the curriculum is updated to no longer use attr_accessible
 gem install protected_attributes
+
+# Create a new app in order to prefetch default gems for `bundle install`
+cd /tmp
+rails new testapp
+rm -rf testapp


### PR DESCRIPTION
Doing one `bundle install` will cause a few more things to be installed and save
bandwidth/about 16 sec at the workshop. Fixes #8.

Since I'm bulking the VM up here, removing `therubyracer` to compensate. Speak up
now if you want it.
