### PR TITLE
Don't install the protected_attributes gem

### DIFF
--- a/provision-user-install.sh
+++ b/provision-user-install.sh
@@ -17,8 +17,6 @@ ln -s /vagrant $HOME/workspace
 
 # Install gems
 gem install rails --version "$RAILSBRIDGE_RAILS_VERSION"
-# Keep this until the curriculum is updated to no longer use attr_accessible
-gem install protected_attributes
 
 # Create a new app in order to prefetch default gems for `bundle install`
 cd /tmp


### PR DESCRIPTION
Protected attributes is for using `attr_accessible` in Rails 4.

The curriculum does not use `attr_accessible`, so we don't need to install the 
gem.
