### PR TITLE
RFC: ruby/rails update

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -1,6 +1,6 @@
 # Change these whenever the curriculum is updated.
 RAILSBRIDGE_RUBY_VERSION='2.0'
-RAILSBRIDGE_RAILS_VERSION='4.0.9'
+RAILSBRIDGE_RAILS_VERSION='4.0.12'
 
 # These are used for installing/selecting Ruby and may need to be bumped
 # for new patchlevels, but should not otherwise need to be changed.


### PR DESCRIPTION
Just bumping the patchlevel of rails 4.0 here, so far.
- Are we ready for Ruby 2.1.5? (this means we're stuck without a tagged version of ruby-install supporting the latest, again)
- Are we ready for Rails 4.1? (depends on curriculum)
