### PR TITLE
Add instructions for accessing the Rails server within Vagrant

### DIFF
--- a/etcfiles/update-motd.d/99-railsbridge
+++ b/etcfiles/update-motd.d/99-railsbridge
@@ -7,7 +7,13 @@ within your computer" running the Linux operating system. Everything you need
 for the Suggestotron tutorial is installed, including: Ruby 2.0, Rails 4.0,
 sqlite3, the heroku toolbelt, and git.
 
-When you start your Rails app, visit http://localhost:3000 in your web browser.
+To start your rails server, type
+
+rails server -b 0.0.0.0
+
+and hit return.
+
+After you start your Rails server, visit http://localhost:3000 in your web browser.
 
 The ~/workspace directory is shared with the folder on your laptop where you
 created this VM. Any file you put there in your laptop will appear here in


### PR DESCRIPTION
Rails 4.2.. doesn't recognize servers run in vagrant as being run locally.
This causes the regular `rails server` command to fail to load the application
on localhost:3000. We could create a patch to fix this and ask student to add it
to their new apps but that seems a little too tricky for new programmers. We
could also create a script that students could run each time before starting the
server, but that would most likely be very confusing. Having students simply
bind to localhost has no future ramifications and is the easiest solution.

@decklin 