### PR TITLE
add the listen-on-all-interfaces app template

### DIFF
--- a/provision-files/home/vagrant/vm.rb
+++ b/provision-files/home/vagrant/vm.rb
@@ -1,0 +1,22 @@
+# RailsBridge VM application template for running inside VirtualBox
+#
+# The VirtualBox NAT interface (which connects the guest to the host) is
+# probably 10.0.2.15, but just in case something changes in the future,
+# listen on all interfaces, and whitelist all 10.* networks.
+
+environment "config.web_console.whitelisted_ips = '10.0.0.0/8'", env: 'development'
+
+append_file 'config/boot.rb', <<EOF
+
+# Configure server for VirtualBox (added by RailsBridge VM)
+
+require 'rails/commands/server'
+
+module Rails
+  class Server
+    def default_options
+      super.merge(Host: '*', Port: 3000)
+    end
+  end
+end
+EOF


### PR DESCRIPTION
This file is a template that can be used at app creation time to change some settings.

This is part of Rails, it's described here: http://guides.rubyonrails.org/rails_application_templates.html

Basically, we have a choice between using `-b 0.0.0.0` with `rails server`, or `-m vm.rb` (this file) with `rails new`. We didn't come to a consensus, so what I am proposing with this PR is:

* we include `vm.rb` in the VM, because that's more convenient than downloading it (maybe?)
* we don't change the docs (they all use `-b 0.0.0.0` currently)
* we have some TAs and advanced students go through it both ways and see how they feel

The important bit of this file could also be copy-and-pasted into `boot.rb` by an advanced student who was already well into developing their app.