### PR TITLE
Upgrade to Rails 5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure('2') do |config|
   # RailsBridge provisioning config
   config.vm.provision :file, source: "provision-files", destination: "/tmp/provision-files"
   config.vm.provision :shell, path: "provision-root-install.sh"
-  config.vm.provision :shell, path: "https://toolbelt.heroku.com/install-ubuntu.sh"
+  config.vm.provision :shell, path: "https://cli-assets.heroku.com/install-ubuntu.sh"
   config.vm.provision :shell, path: "provision-user-install.sh", privileged: false
   config.vm.provision :shell, path: "provision-root-cleanup.sh"
   # Enable forwarded port while we're developing and testing this box

--- a/provision-files/versions.sh
+++ b/provision-files/versions.sh
@@ -1,6 +1,6 @@
 # Change these whenever the curriculum is updated.
 RAILSBRIDGE_RUBY_VERSION='2.3.3'
-RAILSBRIDGE_RAILS_VERSION='4.2.7.1'
+RAILSBRIDGE_RAILS_VERSION='5.1.2'
 
 # We use ruby-install to build Ruby. Before building the VM image, check
 # https://github.com/postmodern/ruby-install/commits/master to see if


### PR DESCRIPTION
This goes along with https://github.com/railsbridge-boston/docs/pull/90

The only change of significance besides bumping the rails version, was to change the heroku toolbelt URL. It appears that it changed in the last 8 months since we last made an image.

Of note, I couldn't actually provision the box without manually downloading the image from vagrant's cloud. I kept getting an error:

```
The box failed to unpackage properly. Please verify that the box
file you're trying to add is not corrupted and that enough disk space
is available and then try again.
The output from attempting to unpackage (if any):

bsdtar: Error opening archive: Unrecognized archive format
```

The way I got around this was downloading the box directly from this url: http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-i386-vagrant.box

Then adding it with:

```bash
vagrant box add "ubuntu/xenial32" xenial-server-cloudimg-i386-vagrant.box
```

And then `vagrant up`-ing as usual.